### PR TITLE
Add magicpathlevel filtering UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -510,14 +510,14 @@
 			<label for="pathN"><input class="toggle-path" type='checkbox' value='N' id="pathN"
 			/><img alt="N" class="Path_N pathicon" src="images/magicicons/Path_N.png" /></label>
 
-			<label for="pathG"><input class="toggle-path" type='checkbox' value='G' id="pathG" 
+			<label for="pathG"><input class="toggle-path" type='checkbox' value='G' id="pathG"
 			/><img alt="G" class="Path_G pathicon" src="images/magicicons/Path_G.png" /></label>
 
 			<label for="pathB"><input class="toggle-path" type='checkbox' value='B' id="pathB"
 			/><img alt="B" class="Path_B pathicon" src="images/magicicons/Path_B.png" /></label>
 		</div>
 		<!-- /PATH CHECKBOXES LINE1 -->
-		
+
 		<!-- PATH CHECKBOXES LINE1 -->
 		<div class="filters-paths  panel siteview">
 			<input type="button" value="X" class="clear-filters-btn" title="clear filters" />
@@ -559,6 +559,106 @@
         </div>
         <!-- /PATH CHECKBOXES LINE2 -->
 
+
+    <!-- PATHLEVEL CHECKBOXES LINE1 -->
+		<div class="filters-pathlevels  panel spellview">
+			<input type="button" value="X" class="clear-filters-btn" title="clear filters" />
+
+			<label for="pathFlevel"><img alt="F" class="Path_F pathicon" src="images/magicicons/Path_F.png"
+			/><input class="level-path" type='number' value='9' min='0' max='9' id="pathFlevel" name="F"
+			/></label>
+
+			<label for="pathAlevel"><img alt="A" class="Path_A pathicon" src="images/magicicons/Path_A.png"
+			/><input class="level-path" type='number' value='9' min='0' max='9' id="pathAlevel" name="A"
+			/></label>
+
+			<label for="pathWlevel"><img alt="W" class="Path_W pathicon" src="images/magicicons/Path_W.png"
+			/><input class="level-path" type='number' value='9' min='0' max='9' id="pathWlevel" name="W"
+			/></label>
+
+			<label for="pathElevel"><img alt="E" class="Path_E pathicon" src="images/magicicons/Path_E.png"
+			/><input class="level-path" type='number' value='9' min='0' max='9' id="pathElevel" name="E"
+			/></label>
+
+			<label for="pathHlevel"><img alt="H" class="Path_H pathicon" src="images/magicicons/Path_H.png"
+			/><input class="level-path" type='number' value='9' min='0' max='9' id="pathHlevel" name="H"
+			/></label>
+
+			<br/>
+
+			<label for="pathSlevel"><img alt="S" class="Path_S pathicon" src="images/magicicons/Path_S.png"
+			/><input class="level-path" type='number' value='9' min='0' max='9' id="pathSlevel" name="S"
+			/></label>
+
+			<label for="pathDlevel"><img alt="D" class="Path_D pathicon" src="images/magicicons/Path_D.png"
+			/><input class="level-path" type='number' value='9' min='0' max='9' id="pathDlevel" name="D"
+			/></label>
+
+			<label for="pathNlevel"><img alt="N" class="Path_N pathicon" src="images/magicicons/Path_N.png"
+			/><input class="level-path" type='number' value='9' min='0' max='9' id="pathNlevel" name="N"
+			/></label>
+
+			<label for="pathGlevel"><img alt="G" class="Path_G pathicon" src="images/magicicons/Path_G.png"
+			/><input class="level-path" type='number' value='9' min='0' max='9' id="pathGlevel" name="G"
+			/></label>
+
+			<label for="pathBlevel"><img alt="B" class="Path_B pathicon" src="images/magicicons/Path_B.png"
+			/><input class="level-path" type='number' value='9' min='0' max='9' id="pathBlevel" name="B"
+			/></label>
+
+			<input type="button" value="0" class="zero-levels-btn" title="zero levels" />
+		</div>
+    <!-- /PATHLEVEL CHECKBOXES LINE1 -->
+
+    <!-- PATHLEVEL CHECKBOXES LINE1 -->
+		<div class="filters-pathlevels  panel itemview">
+			<input type="button" value="X" class="clear-filters-btn" title="clear filters" />
+
+			<label for="pathFlevel"><img alt="F" class="Path_F pathicon" src="images/magicicons/Path_F.png"
+			/><input class="level-path" type='number' value='9' min='0' max='9' id="pathFlevel" name="F"
+			/></label>
+
+			<label for="pathAlevel"><img alt="A" class="Path_A pathicon" src="images/magicicons/Path_A.png"
+			/><input class="level-path" type='number' value='9' min='0' max='9' id="pathAlevel" name="A"
+			/></label>
+
+			<label for="pathWlevel"><img alt="W" class="Path_W pathicon" src="images/magicicons/Path_W.png"
+			/><input class="level-path" type='number' value='9' min='0' max='9' id="pathWlevel" name="W"
+			/></label>
+
+			<label for="pathElevel"><img alt="E" class="Path_E pathicon" src="images/magicicons/Path_E.png"
+			/><input class="level-path" type='number' value='9' min='0' max='9' id="pathElevel" name="E"
+			/></label>
+
+			<label for="pathHlevel"><img alt="H" class="Path_H pathicon" src="images/magicicons/Path_H.png"
+			/><input class="level-path" type='number' value='9' min='0' max='9' id="pathHlevel" name="H"
+			/></label>
+
+			<br/>
+
+			<label for="pathSlevel"><img alt="S" class="Path_S pathicon" src="images/magicicons/Path_S.png"
+			/><input class="level-path" type='number' value='9' min='0' max='9' id="pathSlevel" name="S"
+			/></label>
+
+			<label for="pathDlevel"><img alt="D" class="Path_D pathicon" src="images/magicicons/Path_D.png"
+			/><input class="level-path" type='number' value='9' min='0' max='9' id="pathDlevel" name="D"
+			/></label>
+
+			<label for="pathNlevel"><img alt="N" class="Path_N pathicon" src="images/magicicons/Path_N.png"
+			/><input class="level-path" type='number' value='9' min='0' max='9' id="pathNlevel" name="N"
+			/></label>
+
+			<label for="pathGlevel"><img alt="G" class="Path_G pathicon" src="images/magicicons/Path_G.png"
+			/><input class="level-path" type='number' value='9' min='0' max='9' id="pathGlevel" name="G"
+			/></label>
+
+			<label for="pathBlevel"><img alt="B" class="Path_B pathicon" src="images/magicicons/Path_B.png"
+			/><input class="level-path" type='number' value='9' min='0' max='9' id="pathBlevel" name="B"
+			/></label>
+
+			<input type="button" value="0" class="zero-levels-btn" title="zero levels" />
+		</div>
+    <!-- /PATHLEVEL CHECKBOXES LINE1 -->
 
         <!-- ITEM FILTERS LINE1 -->
 		<div class="filters-items  panel itemview">

--- a/scripts/DMI/CGrid.js
+++ b/scripts/DMI/CGrid.js
@@ -167,6 +167,7 @@ DMI.CGrid = Utils.Class(function( domname, data, columns, options) {
 			if ($property.find(" input[type=text]:[value^='']").length
 				|| $property.find(" textarea:[value^='']").length
 				|| $property.find(" input[type=checkbox]:checked").length
+				|| $property.find(" input[type=number]:[value!='9']").length
 				|| ($property.find(" option:not(.default):selected").length && !($property.find(" select.nation").length))
 				|| ($property.find(":selected")[0] && $property.find(":selected")[0].text != "any nation" && $property.find(" select.nation").length)
 			)
@@ -178,6 +179,7 @@ DMI.CGrid = Utils.Class(function( domname, data, columns, options) {
 			if ($panel.find(" input[type=text]:[value^='']").length
 				|| $panel.find(" textarea:[value^='']").length
 				|| $panel.find(" input[type=checkbox]:checked").length
+				|| $panel.find(" input[type=number]:[value!='9']").length
 				|| ($panel.find(" option:not(.default):selected").length && !($panel.find(" select.nation").length))
 				|| ($panel.find(":selected")[0] && $panel.find(":selected")[0].text != "any nation" && $panel.find(" select.nation").length)
 			)
@@ -206,6 +208,7 @@ DMI.CGrid = Utils.Class(function( domname, data, columns, options) {
 		checkClearFilters.call(this);
 	});
 	$(that.domselp+" input[type=checkbox]").bind('change click', 	function(e) { that.doSearch(); $(this).saveState(); checkClearFilters.call(this); });
+	$(that.domselp+" input[type=number]").bind('change click', 	function(e) { that.doSearch(); $(this).saveState(); checkClearFilters.call(this); });
 	$(that.domselp+" select").bind('change', 			function(e) { that.doSearch(); $(this).saveState(); checkClearFilters.call(this); });
 	$(that.domselp+" input.clear-filters-btn").click(function(e) {
 		$panel = $(this).parents('.panel');
@@ -216,11 +219,23 @@ DMI.CGrid = Utils.Class(function( domname, data, columns, options) {
 		//clear inputs and select default options
 		$panel.find(" input[type=text]").val('').saveState();
 		$panel.find(" textarea").val('').saveState();
+		$panel.find(" input.level-path").val('9').saveState();
 		$panel.find(" input[type=checkbox]:checked:not(#loadEvents)").prop("checked", false).saveState();
 		$panel.find(" option.default").attr('selected', true).parent().saveState();
 		$panel.find('#nation').val(null).trigger('change');
 		$(this).hide();
 
+		checkGlobalClearFilters();
+		that.doSearch();
+
+		$panel.find(" input[type=text]").first().focus();
+	});
+	$(that.domselp+" input.zero-levels-btn").click(function(e) {
+		$panel = $(this).parents('.panel');
+
+		$(that.domselp+" input.level-path").val('0').saveState();
+
+		checkClearFilters.call(this);
 		checkGlobalClearFilters();
 		that.doSearch();
 

--- a/scripts/DMI/MItem.js
+++ b/scripts/DMI/MItem.js
@@ -278,6 +278,7 @@ MItem.CGrid = Utils.Class( DMI.CGrid, function() {
 			nation: $(that.domselp+" select.nation").val(),
 			generic: $(that.domselp+" input.generic:checked").val(),
 			national: $(that.domselp+" input.national:checked").val(),
+			mlevels: {},
 			mpaths: ''
 		};
 		args.properties = Utils.propertiesWithKeys(args.properties);
@@ -296,6 +297,10 @@ MItem.CGrid = Utils.Class( DMI.CGrid, function() {
 		$(that.domselp+' .toggle-path:checked').each(function() {
 			args.mpaths += this.value;
 		});
+
+		$(that.domselp+' .level-path').each(function() {
+			args.mlevels[this.name] = this.value;
+		});
 		return args;
 	}
 	//apply search
@@ -312,6 +317,14 @@ MItem.CGrid = Utils.Class( DMI.CGrid, function() {
 		//search string
 		if (args.str && o.searchable.indexOf(args.str) == -1)
 			return false;
+
+		//magic levels
+		if (args.mlevels) {
+			if(args.mlevels[o.mainpath] < o.mainlevel)
+				return false;
+			if(o.secondarypath && args.mlevels[o.secondarypath] < o.secondarylevel)
+				return false;
+		}
 
 		//magic paths
 		if (args.mpaths) {

--- a/scripts/DMI/MSpell.js
+++ b/scripts/DMI/MSpell.js
@@ -597,6 +597,7 @@ MSpell.CGrid = DMI.Utils.Class( DMI.CGrid, function() {
 
 			aquatic: $(that.domselp+" select.aquatic").val(),
 
+			mlevels: {},
 			mpaths: ''
 		};
 		args.properties = Utils.propertiesWithKeys(args.properties);
@@ -613,6 +614,10 @@ MSpell.CGrid = DMI.Utils.Class( DMI.CGrid, function() {
 		//create string of mpaths from checkboxes
 		$(that.domselp+' .toggle-path:checked').each(function() {
 			args.mpaths += this.value;
+		});
+
+		$(that.domselp+' .level-path').each(function() {
+			args.mlevels[this.name] = this.value;
 		});
 		return args;
 	}
@@ -697,6 +702,14 @@ MSpell.CGrid = DMI.Utils.Class( DMI.CGrid, function() {
 		//search string
 		if (args.str && o.searchable.indexOf(args.str) == -1)
 			return false;
+
+		//magic levels
+		if (args.mlevels) {
+			if(args.mlevels[o.path1] < o.pathlevel1)
+				return false;
+			if(o.path2 && args.mlevels[o.path2] < o.pathlevel2)
+				return false;
+		}
 
 		//magic paths
 		if (args.mpaths) {

--- a/scripts/master.css
+++ b/scripts/master.css
@@ -288,6 +288,18 @@ input.clear-filters-btn, #global-clear-filters-btn{
 	clear:right;
 }
 
+input.zero-levels-btn{
+	font-weight:bold;
+	font-size: 8pt;
+	padding:0px;
+	width: 18px;
+	height:18px;
+
+	display:block;
+	float:right;
+	clear:right;
+}
+
 /****************************************
 	filter buttons 
 ****************************************/
@@ -320,6 +332,24 @@ input.clear-filters-btn, #global-clear-filters-btn{
 	position:relative;
 	left: -5px;
 	
+	margin-right:-5px;
+}
+
+.level-path {
+	width:30px;
+	/*height:10px;*/
+	vertical-align: middle;
+	padding:0px; margin:0px;
+	margin-left:0px;
+}
+.level-path + label {
+	padding:0px; margin:0px;
+}
+.level-path + label img {
+	padding:0px; margin:0px;
+	position:relative;
+	left: -5px;
+
 	margin-right:-5px;
 }
 


### PR DESCRIPTION
# Problem
I cannot filter spells or items lists based on what magic path levels my mage has. For example I cannot list all spells castable by a D1N1 empoisoner.

# Suggested fix
1. Add new UI elements to filter listings based on magic path levels for each path
2. Add small UI element to set all level filters to zero (no spells shown) instead of default 9 (all spells shown)

# Possible future improvements

- Add "List castable spells" link to the unit card. The link would navigate to Spells page and set the filters according to the units magic path levels.
- Add "List forgeable items" link to the unit card. The link would navigate to Items page and set the filters according to the units magic path levels.

# Testing

- Works on my machine
- Testable at https://random-cdda-modder.github.io/dom6inspector/
- All other search options seem to still work
- Only Items and Spells search was modified, other pages still seem to work
- Found a spell without any path requirements, ID 697 Cave Collapse, another reason to not enter any caves ever.