### PR TITLE
add option to hide descriptions.

### DIFF
--- a/index.html
+++ b/index.html
@@ -895,8 +895,11 @@
 		<label for="showkeys" title="shows searchable keys. generally these correspond to mod command names"
 		><input id="showkeys" type='checkbox' name="keys" value="keys" title="shows searchable keys. generally these correspond to mod command names" 
 		/>show keys</label>
-		</div>
 
+		<label for="hidedescriptions" title="hides ingame description texts to save screen space"
+		><input id="hidedescriptions" type='checkbox' name="hidedescriptions" value="hidedescriptions" title="hides ingame description texts to save screen space"
+		/>hide descriptions</label>
+		</div>
 	</div>
 	
 	

--- a/scripts/DMI/Utils.js
+++ b/scripts/DMI/Utils.js
@@ -8,6 +8,7 @@ Options['Show database keys'] = 0;
 Options['Show ids'] = 0;
 Options['Show popup refs'] = 1;
 Options['Show internal keys'] = 1;
+Options['Show descriptions'] = 1;
 
 //loaded from query string
 Options['Show mod cmds'] = null;

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -102,6 +102,7 @@ DMI.initGrids = function() {
 		showOrHideModdingInfo();
 		showOrHideKeys();
 		showOrHideModCmds();
+		showOrHideDescriptions();
 	}
 	$('#showids').click( function(){setTimeout(showOrHideIds,0);} ); //asynchronous call as its a bit sluggish
 
@@ -152,6 +153,18 @@ DMI.initGrids = function() {
 	}
 	$('#showmodcmds').click( function(){setTimeout(showOrHideModCmds,0);} );  //asynchronous call as its a bit sluggish
 
+	function showOrHideDescriptions() {
+		if ($('#hidedescriptions').saveState().is(':checked')) {
+			$( "<style>.overlay-descr { display:none !important; }</style>" ).appendTo( "head" );
+
+			DMI.Options['Show descriptions'] = 0;
+		}
+		else {
+			$( "<style>.overlay-descr { display:block !important; }</style>" ).appendTo( "head" );
+			DMI.Options['Show descriptions'] = 1;
+		}
+	}
+	$('#hidedescriptions').click( function(){setTimeout(showOrHideDescriptions,0);} );  //asynchronous call as its a bit sluggish
 
 
 	//jquery plugin. no shit


### PR DESCRIPTION
Adds an advanced option checkbox to hide long description texts in case user wants to save space on screen while displaying many open cards

testable at https://random-cdda-modder.github.io/dom6inspector/