### PR TITLE
Minor mod parsing fixes

### DIFF
--- a/scripts/DMI/MSite.js
+++ b/scripts/DMI/MSite.js
@@ -131,6 +131,11 @@ MSite.prepareData_PostMod = function() {
 			o.rarity = parseInt(o.rarity);
 		}
 
+		// if o_name is missing, use the site id as the name
+		if (!o.name || o.name == '') {
+			o.name = 'site_' + o.id;
+		}
+
 		//searchable string
 		o.searchable = o.name.toLowerCase();
 

--- a/scripts/parsemod.js
+++ b/scripts/parsemod.js
@@ -395,7 +395,35 @@ var modctx = DMI.modctx = {
 		},
 
 		selectsite: function(c,a,t,fnw){
-			modctx._select(c,a,'site',fnw);
+			try {
+				// First, try to select an existing site
+				modctx._select(c,a,'site',fnw);
+			}
+			catch(e) {
+				// Create a new site if it doesn't exist
+				if (e == 'data not found' && a.n1) {
+					// If no specific ID is given, find the first unused ID
+					if (a.n1 == '' || a.n1 == '0') {
+						var id = modctx.sitedata.length;
+						while (modctx.sitelookup[id]) id++;
+						a.n1 = id;
+					} else {
+						// If a specific ID is given, only increment if it's already in use
+						var id = parseInt(a.n1);
+						if (modctx.sitelookup[id]) {
+							while (modctx.sitelookup[id]) {
+								id++;
+							}
+							a.n1 = id;
+						}
+					}
+
+					// Create a new site
+					modctx._new(c, a, 'site', fnw);
+					DMI.MSite.initSite(modctx.site);
+				}
+				else throw e;
+			}
 		},
 
 		newevent: function(c,a,t,fnw) {

--- a/scripts/parsemod.js
+++ b/scripts/parsemod.js
@@ -1085,7 +1085,9 @@ var modctx = DMI.modctx = {
 			for (var i=0, m; m= from.randompaths[i]; i++) to.randompaths[i] = m;
 
 			to.startitem = [];
-			for (var i=0, m; m= from.startitem[i]; i++) to.startitem[i] = m;
+			if (from.startitem) {
+				for (var i=0, m; m= from.startitem[i]; i++) to.startitem[i] = m;
+			}
 		},
 		copyspr: function(c,a,t){
 			var from = modctx.unitlookup[a.n1] || modctx.unitlookup[$.trim((a.s || '-1').toLowerCase())];


### PR DESCRIPTION
**Added a fallback mechanism for generating a searchable string for sites without names**  
This could result in error when trying to load a mod working on different game version with additional sites, e.g. SCBM 1.07 making use of patch 6.24 newly added sites (while mod inspector is at 6.21), so I added a fallback name in the rare case it happens

**Added null/undefined check for startitem array during unit stats copying**
When loading some mods we can get an error with startitem copying. Haven't found out the cause yet, but this change should at least allow us to proceed with opening up the mod inspector.

**When parsing mods, selectsite is sometimes used to generate new sites**
Modders sometimes use #selectsite instead of #newsite for generating new sites. This change should ensure that in the case this happens, we get similiar behavior to newsite instead of missing sites.

