### PR TITLE
Fix templetrainer property to use actual unit references

### DIFF
--- a/scripts/DMI/MUnit.js
+++ b/scripts/DMI/MUnit.js
@@ -2267,7 +2267,7 @@ var displayorder_other = Utils.cutDisplayOrder(aliases, formats,
 	'astralfetters', 'astral fetters',
 	'foreignmagicboost', 'foreign magic boost',
 	'templetrainer', 'temple summon', function(v,o){
-		return Utils.unitRef('1859');
+		return Utils.unitRef(v);
 	},
 	'addrandomage', 'add random age',
 	'unsurr', 'unsurroundable',


### PR DESCRIPTION
Updates MUnit.js to use the actual unit ID from the templetrainer property instead of hardcoding to unit #1859, allowing proper display of temple summon units