### PR TITLE
Ensure that #size changing in mods correctly sets #ressize if it hadn't been explicity set

### DIFF
--- a/scripts/DMI/MUnit.js
+++ b/scripts/DMI/MUnit.js
@@ -154,6 +154,14 @@ MUnit.prepareData_PreMod = function() {
 		o.nationname = '';
 		o.weapons = Utils.keyListToTable(o, 'wpn');
 
+		// Check if size and ressize are different
+        	// If they are, we mark ressize as explicitly set
+	        if (o.size && o.ressize && parseInt(o.size) !== parseInt(o.ressize)) {
+	            o._ressizeExplicitlySet = true;
+	        } else {
+	            o._ressizeExplicitlySet = false;
+	        }
+
 		if (!o.startitem) {
 			o.startitem = [];
 		} else {

--- a/scripts/parsemod.js
+++ b/scripts/parsemod.js
@@ -1136,8 +1136,22 @@ var modctx = DMI.modctx = {
 		mapmove:_num,
 		hp:	_num,
 		prot:	_num,
-		size:	_num,
-		ressize:_num,
+		size: function(c, a, t) {
+		    // Set the regular size property
+		    modctx[t][c] = argnum(a);
+		    
+		    // Only update ressize if it hasn't been explicitly set
+		    if (!modctx[t]['_ressizeExplicitlySet']) {
+		        modctx[t]['ressize'] = argnum(a);
+		    }
+		},
+		ressize: function(c, a, t) {
+		    // Mark that ressize has been explicitly set
+		    modctx[t]['_ressizeExplicitlySet'] = true;
+		    
+		    // Then perform the regular number assignment
+		    modctx[t][c] = argnum(a);
+		},
 		str:	_num,
 		enc:	_num,
 		att:	_num,


### PR DESCRIPTION
Some mods change the #size of the unit, but this doesn't update the #ressize, and in result we will end up with wrong #rcost.

This change should ensure that if a mods changes the #size of the unit, and the initial #ressize wasn't set by vanilla game behavior or a mod, we will replace #ressize with #size which should result in correct #rcost values.