### PR TITLE
Add _ressizeExplicitlySet to ignorekeys in MUnit.js

### DIFF
--- a/scripts/DMI/MUnit.js
+++ b/scripts/DMI/MUnit.js
@@ -2612,7 +2612,9 @@ var ignorekeys = {
 	
 	//common fields
 	name:1,linkname:1,descr:1,
-	searchable:1, renderOverlay:1, matchProperty:1
+	searchable:1, renderOverlay:1, matchProperty:1,
+
+	_ressizeExplicitlySet:1
 };
 
 MUnit.renderOverlay = function(o, isPopup) {


### PR DESCRIPTION
My bad, forgot to add the flag _ressizeExplicitlySet to ignorekeys in MUnit.js so it doesn't show up on unit overlay

Related to #24