### PR TITLE
Fix missing attribute lookup errors in spell rendering

### DIFF
--- a/scripts/DMI/MSpell.js
+++ b/scripts/DMI/MSpell.js
@@ -34,7 +34,34 @@ MSpell.nationList = function (o) {
 	return o.nations;
 }
 
+MSpell.ensureAttributeExists = function (attributeId, name) {
+	if (!modctx.attribute_keys_lookup[attributeId]) {
+		// console.log("Adding missing attribute to lookup: " + attributeId + " - " + name);
+		// Create a placeholder entry in the lookup
+		modctx.attribute_keys_lookup[attributeId] = {
+			number: attributeId,
+			name: name || "Unknown Attribute (" + attributeId + ")"
+		};
+	}
+}
+
+MSpell.initializeMissingAttributes = function () {
+	// First, we collect all attribute IDs used in the game
+	var usedAttributes = {};
+
+	for (var i = 0, attr; attr = modctx.attributes_by_spell[i]; i++) {
+		usedAttributes[attr.attribute] = true;
+	}
+
+	// Then ensure each used attribute exists in the lookup
+	for (var attrId in usedAttributes) {
+		MSpell.ensureAttributeExists(attrId);
+	}
+}
+
+
 MSpell.prepareData_PreMod = function() {
+	MSpell.initializeMissingAttributes();
 	for (var oi=0, o;  o= modctx.spelldata[oi];  oi++) {
 
 		o.path1  = modconstants[16][o.path1];


### PR DESCRIPTION
This PR fixes #23

Added code that dynamically adds "Unknown Attribute {id}" to missing attributes.

This should probably be done by using dom6utils and updating attribute_keys.csv, but haven't touched dom6utils yet.

In this case, it affects the following spells and why they don't show up in overlay:

Missing attribute 1713 for spell 537 - Call the Birds of Splendor
Missing attribute 1715 for spell 1159 - Twiceborn
Missing attribute 1716 for spell 220 - Divine Blessing
Missing attribute 1716 for spell 242 - Fanaticism
Missing attribute 1716 for spell 380 - Unholy Blessing
Missing attribute 1716 for spell 381 - Protection of the Sepulchre
Missing attribute 1716 for spell 382 - Power of the Sepulchre
Missing attribute 1716 for spell 412 - Unholy Blessing
Missing attribute 1716 for spell 413 - Protection of the Shadelands
Missing attribute 1716 for spell 414 - Power of the Shadelands
Missing attribute 1716 for spell 422 - Royal Protection
Missing attribute 1716 for spell 423 - Power of the Reborn King
Missing attribute 1716 for spell 433 - Puppet Mastery
Missing attribute 1716 for spell 434 - Carrion Growth